### PR TITLE
Delete .env

### DIFF
--- a/trivter/.env
+++ b/trivter/.env
@@ -1,1 +1,0 @@
-OPENAI_API_KEY=


### PR DESCRIPTION
Removed environment file. This can instead be set up locally without the .env file.